### PR TITLE
Small ObjectDef fix for HPZ/Waterfall.txt

### DIFF
--- a/Sonic 2/Scripts/HPZ/Waterfall.txt
+++ b/Sonic 2/Scripts/HPZ/Waterfall.txt
@@ -242,13 +242,13 @@ event RSDKLoad
 	AddEnumVariable("96 pixels", 6)
 	AddEnumVariable("112 pixels", 7)
 
-	AddEditorVariable("hasSplash")
-	SetActiveVariable("hasSplash")
+	AddEditorVariable("noRidge")
+	SetActiveVariable("noRidge")
 	AddEnumVariable("false", false)
 	AddEnumVariable("true", true)
 	
-	AddEditorVariable("noRidge")
-	SetActiveVariable("noRidge")
+	AddEditorVariable("hasSplash")
+	SetActiveVariable("hasSplash")
 	AddEnumVariable("false", false)
 	AddEnumVariable("true", true)
 end event


### PR DESCRIPTION
noRidge & hasSplash where in the wrong order.