### PR TITLE
Fix all PushButton.txt objects for Sonic 2

### DIFF
--- a/Sonic 2/Scripts/MBZ/PushButton.txt
+++ b/Sonic 2/Scripts/MBZ/PushButton.txt
@@ -55,7 +55,7 @@ event ObjectUpdate
 			if checkResult == COL_TOP
 				object.stood 	= true
 				object.pressed 	= true
-				player[currentPlayer].ypos += 40000
+				player[currentPlayer].ypos += 0x40000
 				PlaySfx(SfxName[Button Press], false)
 				
 				object[+1].priority = PRIORITY_ACTIVE

--- a/Sonic 2/Scripts/MPZ/PushButton.txt
+++ b/Sonic 2/Scripts/MPZ/PushButton.txt
@@ -55,7 +55,7 @@ event ObjectUpdate
 			if checkResult == COL_TOP
 				object.stood = true
 				object.pressed = true
-				player[currentPlayer].ypos += 40000
+				player[currentPlayer].ypos += 0x40000
 				PlaySfx(SfxName[Button Press], false)
 			end if
 		else

--- a/Sonic 2/Scripts/OOZ/PushButton.txt
+++ b/Sonic 2/Scripts/OOZ/PushButton.txt
@@ -55,7 +55,7 @@ event ObjectUpdate
 			if checkResult == COL_TOP
 				object.stood = true
 				object.pressed = true
-				player[currentPlayer].ypos += 40000
+				player[currentPlayer].ypos += 0x40000
 				PlaySfx(SfxName[Button Press], false)
 			end if
 		else


### PR DESCRIPTION
Small fix for Sonic 2's `PushButton.txt` objects in MPZ, OOZ, and MBZ. All of these increases the Player's ypos value by `40000`, when it most likely should be `0x40000`.